### PR TITLE
fix: delay of new session shortened to ~5s instead of ~45s

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -218,13 +218,12 @@ def voice_proxy(ws: simple_websocket.ws.Server):
 
     logger.info("New WebSocket connection")
 
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    loop.run_until_complete(voice_proxy_handler.handle_connection(ws))
+        loop.run_until_complete(voice_proxy_handler.handle_connection(ws))
+    finally:
+        loop.close()
 
 
 @app.route(API_GRAPH_SCENARIO_ENDPOINT, methods=["POST"])

--- a/backend/src/services/analyzers.py
+++ b/backend/src/services/analyzers.py
@@ -344,9 +344,9 @@ class PronunciationAssessor:
             wav_buffer.seek(0)
             return wav_buffer.read()
 
-    def _log_assessment_info(self, wav_audio: bytes, reference_text: Optional[str]) -> None:
+    def _log_assessment_info(self, pcm_audio: bytes, reference_text: Optional[str]) -> None:
         """Log information about the assessment being performed."""
-        logger.info("Starting pronunciation assessment with audio size: %s bytes", len(wav_audio))
+        logger.info("Starting pronunciation assessment with audio size: %s bytes", len(pcm_audio))
         logger.info("Reference text: %s", reference_text or "None")
         logger.info("Speech key configured: %s", "Yes" if self.speech_key else "No")
         logger.info("Speech region: %s", self.speech_region)
@@ -368,8 +368,8 @@ class PronunciationAssessor:
         pronunciation_config.enable_prosody_assessment()
         return pronunciation_config
 
-    def _create_audio_config(self, wav_audio: bytes) -> speechsdk.audio.AudioConfig:
-        """Create audio configuration from WAV data."""
+    def _create_audio_config(self, pcm_audio: bytes) -> speechsdk.audio.AudioConfig:
+        """Create audio configuration from raw PCM data."""
         audio_format = speechsdk.audio.AudioStreamFormat(
             samples_per_second=AUDIO_SAMPLE_RATE,
             bits_per_sample=AUDIO_BITS_PER_SAMPLE,
@@ -378,7 +378,7 @@ class PronunciationAssessor:
         )
 
         push_stream = speechsdk.audio.PushAudioInputStream(stream_format=audio_format)
-        push_stream.write(wav_audio)
+        push_stream.write(pcm_audio)
         push_stream.close()
 
         return speechsdk.audio.AudioConfig(stream=push_stream)
@@ -426,8 +426,7 @@ class PronunciationAssessor:
             if len(combined_audio) < MIN_AUDIO_SIZE_BYTES:
                 logger.warning("Audio might be too short: %s bytes", len(combined_audio))
 
-            wav_audio = self._create_wav_audio(combined_audio)
-            return await self._perform_assessment(wav_audio, reference_text)
+            return await self._perform_assessment(bytes(combined_audio), reference_text)
 
         except Exception as e:
             logger.error("Error in pronunciation assessment: %s", e)
@@ -447,13 +446,13 @@ class PronunciationAssessor:
 
         return combined_audio
 
-    async def _perform_assessment(self, wav_audio: bytes, reference_text: Optional[str]) -> Optional[Dict[str, Any]]:
+    async def _perform_assessment(self, pcm_audio: bytes, reference_text: Optional[str]) -> Optional[Dict[str, Any]]:
         """Perform the actual pronunciation assessment."""
-        self._log_assessment_info(wav_audio, reference_text)
+        self._log_assessment_info(pcm_audio, reference_text)
 
         speech_config = self._create_speech_config()
         pronunciation_config = self._create_pronunciation_config(reference_text)
-        audio_config = self._create_audio_config(wav_audio)
+        audio_config = self._create_audio_config(pcm_audio)
 
         speech_recognizer = speechsdk.SpeechRecognizer(
             speech_config=speech_config,
@@ -464,8 +463,28 @@ class PronunciationAssessor:
 
         result = await asyncio.get_event_loop().run_in_executor(None, speech_recognizer.recognize_once)
 
-        pronunciation_result = speechsdk.PronunciationAssessmentResult(result)
-        return self._build_assessment_result(pronunciation_result, result)
+        if result.reason == speechsdk.ResultReason.RecognizedSpeech:
+            logger.info("Speech recognized: %s", result.text[:100])
+            pronunciation_result = speechsdk.PronunciationAssessmentResult(result)
+            return self._build_assessment_result(pronunciation_result, result)
+
+        if result.reason == speechsdk.ResultReason.NoMatch:
+            details = result.no_match_details
+            logger.warning("Speech not recognized (NoMatch): reason=%s", details.reason if details else "unknown")
+            return None
+
+        if result.reason == speechsdk.ResultReason.Canceled:
+            cancellation = result.cancellation_details
+            logger.error(
+                "Speech recognition canceled: reason=%s, error_code=%s, error_details=%s",
+                cancellation.reason,
+                cancellation.error_code,
+                cancellation.error_details,
+            )
+            return None
+
+        logger.warning("Unexpected recognition result reason: %s", result.reason)
+        return None
 
     def _extract_word_details(self, result: speechsdk.SpeechRecognitionResult) -> List[Dict[str, Any]]:
         """Extract word-level pronunciation details."""

--- a/backend/src/services/websocket_handler.py
+++ b/backend/src/services/websocket_handler.py
@@ -251,6 +251,10 @@ class VoiceProxyHandler:
 
         for task in pending:
             task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def _forward_client_to_azure(
         self,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -78,7 +78,7 @@ export default function App() {
     updateCustomScenario,
     deleteCustomScenario,
   } = useScenarios()
-  const { playAudio } = useAudioPlayer()
+  const { playAudio, resetAudio } = useAudioPlayer()
   const activeScenario =
     selectedScenarioData ||
     scenarios.find(s => s.id === selectedScenario) ||
@@ -141,6 +141,9 @@ export default function App() {
 
   const handleStart = async (avatarValue: string) => {
     if (!selectedScenario) return
+
+    resetAudio()
+    clearMessages()
 
     try {
       const avatarConfig = parseAvatarValue(avatarValue)

--- a/frontend/src/hooks/useAudioPlayer.ts
+++ b/frontend/src/hooks/useAudioPlayer.ts
@@ -16,6 +16,14 @@ export function useAudioPlayer() {
     return audioCtxRef.current
   }, [])
 
+  const resetAudio = useCallback(() => {
+    nextPlayTimeRef.current = 0
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close()
+      audioCtxRef.current = null
+    }
+  }, [])
+
   const playAudio = useCallback(
     (base64: string) => {
       const audioCtx = initAudio()
@@ -46,5 +54,5 @@ export function useAudioPlayer() {
     [initAudio]
   )
 
-  return { playAudio }
+  return { playAudio, resetAudio }
 }

--- a/frontend/src/hooks/useRealtime.ts
+++ b/frontend/src/hooks/useRealtime.ts
@@ -89,7 +89,9 @@ export function useRealtime(options: RealtimeOptions) {
       }
     }
 
-    ws.onclose = () => setConnected(false)
+    ws.onclose = () => {
+      setConnected(false)
+    }
     wsRef.current = ws
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.agentId])
@@ -115,9 +117,10 @@ export function useRealtime(options: RealtimeOptions) {
   )
 
   useEffect(() => {
+    if (!options.agentId) return
     connect()
     return () => wsRef.current?.close()
-  }, [connect])
+  }, [connect, options.agentId])
 
   return {
     connected,

--- a/frontend/src/hooks/useRecorder.ts
+++ b/frontend/src/hooks/useRecorder.ts
@@ -43,6 +43,7 @@ export function useRecorder(onAudioChunk: (base64: string) => void) {
   const [recording, setRecording] = useState(false)
   const audioCtxRef = useRef<AudioContext | null>(null)
   const workletRef = useRef<AudioWorkletNode | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
   const audioRecording = useRef<any[]>([])
 
   const initAudio = useCallback(async () => {
@@ -73,6 +74,7 @@ export function useRecorder(onAudioChunk: (base64: string) => void) {
         echoCancellation: true,
       },
     })
+    streamRef.current = stream
 
     const source = audioCtx.createMediaStreamSource(stream)
     const worklet = new AudioWorkletNode(audioCtx, 'audio-recorder')
@@ -109,6 +111,10 @@ export function useRecorder(onAudioChunk: (base64: string) => void) {
       workletRef.current.port.postMessage({ command: 'STOP' })
       workletRef.current.disconnect()
       workletRef.current = null
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop())
+      streamRef.current = null
     }
     setRecording(false)
   }, [])

--- a/frontend/src/hooks/useWebRTC.ts
+++ b/frontend/src/hooks/useWebRTC.ts
@@ -3,14 +3,34 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { useRef, useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 export function useWebRTC(onSendOffer: (sdp: string) => void) {
   const pcRef = useRef<RTCPeerConnection | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
+  const audioElementsRef = useRef<HTMLAudioElement[]>([])
 
   const setupWebRTC = useCallback(
     async (iceServers: any, username?: string, password?: string) => {
+      // Clear any pending ICE gathering timeout from a previous connection
+      if (gatheringTimeoutRef.current) {
+        clearTimeout(gatheringTimeoutRef.current)
+        gatheringTimeoutRef.current = null
+      }
+
+      // Close existing peer connection before creating a new one
+      if (pcRef.current) {
+        pcRef.current.close()
+        pcRef.current = null
+      }
+
+      // Remove previously injected audio elements
+      audioElementsRef.current.forEach(el => {
+        el.srcObject = null
+        el.remove()
+      })
+      audioElementsRef.current = []
+
       let servers = Array.isArray(iceServers)
         ? iceServers
         : [{ urls: iceServers }]
@@ -28,17 +48,28 @@ export function useWebRTC(onSendOffer: (sdp: string) => void) {
         bundlePolicy: 'max-bundle',
       })
 
+      let offerSent = false
+      const sendOfferOnce = () => {
+        if (offerSent || !pc.localDescription) return
+        offerSent = true
+        const sdp = btoa(
+          JSON.stringify({
+            type: 'offer',
+            sdp: pc.localDescription.sdp,
+          })
+        )
+        onSendOffer(sdp)
+      }
+
       pc.onicecandidate = e => {
-        if (!e.candidate && pc.localDescription) {
-          const sdp = btoa(
-            JSON.stringify({
-              type: 'offer',
-              sdp: pc.localDescription.sdp,
-            })
-          )
-          onSendOffer(sdp)
+        if (!e.candidate) {
+          sendOfferOnce()
         }
       }
+
+      // Fallback: send offer after 3s even if ICE gathering hasn't completed.
+      // Avoids ~30s delays when TURN servers are slow on reconnection.
+      gatheringTimeoutRef.current = setTimeout(sendOfferOnce, 3000)
 
       pc.ontrack = e => {
         if (e.track.kind === 'video' && videoRef.current) {
@@ -50,6 +81,7 @@ export function useWebRTC(onSendOffer: (sdp: string) => void) {
           audio.autoplay = true
           audio.style.display = 'none'
           document.body.appendChild(audio)
+          audioElementsRef.current.push(audio)
         }
       }
 
@@ -77,9 +109,17 @@ export function useWebRTC(onSendOffer: (sdp: string) => void) {
     }
   }, [])
 
+  const gatheringTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
     return () => {
+      if (gatheringTimeoutRef.current) clearTimeout(gatheringTimeoutRef.current)
       pcRef.current?.close()
+      audioElementsRef.current.forEach(el => {
+        el.srcObject = null
+        el.remove()
+      })
+      audioElementsRef.current = []
     }
   }, [])
 


### PR DESCRIPTION
## Purpose

> [!NOTE]
> This fix only applies to locahost, the deployed container app still has a long delay.

When refreshing the page and starting a new session, the avatar and voice has a startup delay of approx. 45 seconds. This PR aims to solve that issue by reducing the avatar to be generated much faster as well as the TTS on new session.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## How to Test

```
git clone https://github.com/aryxenv/voicelive-api-salescoach
cd voicelive-api-salescoach
git checkout fix/ws-connection-delay-on-refresh
```

terminal 1:
```bash
cd frontend
npm install
```

> [!NOTE]
> Verify that the `.env` file is there and contains the right values.

terminal 2 (using uv):
```bash
cd backend
uv venv
uv pip install -r ./requirements.txt
uv run python -m src.app
```

## What to Check
- If you see frontend socket errors, they are not bugs/errors, these can be ignored.
- on the browser at `localhost:5173`
- select a scenario and start
- refresh the page
- select a scenario again
- takes ~5s for avatar and voice to load, instead of ~45s